### PR TITLE
Update to Python 3 for Kodi 19 (matrix)

### DIFF
--- a/plugin.program.steamlink/addon.py
+++ b/plugin.program.steamlink/addon.py
@@ -1,5 +1,5 @@
 """
-Steamlink Launcher for Kodi
+Steamlink Launcher for Kodi 19.4
 """
 
 import os
@@ -12,7 +12,7 @@ from subprocess import check_call
 class KodiAddon(object):
     def __init__(self):
         self._addon = xbmcaddon.Addon()
-        self.path = self._addon.getAddonInfo('path').decode('utf-8')
+        self.path = self._addon.getAddonInfo('path')
     
     def run(self):
         check_call(['bash', self.path + '/resources/lib/start.sh'])

--- a/plugin.program.steamlink/addon.xml
+++ b/plugin.program.steamlink/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.program.steamlink" name="Steamlink Launcher" version="0.0.2" provider-name="bigbrozer">
+<addon id="plugin.program.steamlink" name="Steamlink Launcher" version="1.0.0" provider-name="bigbrozer">
   <requires>
-    <import addon="xbmc.python" version="2.25.0"/>
+    <import addon="xbmc.python" version="3.0.0"/>
   </requires>
   <extension point="xbmc.python.pluginsource" library="addon.py">
     <provides>executable</provides>
@@ -18,6 +18,7 @@
     <email>besancon.vincent@gmail.com</email>
     <source>https://github.com/bigbrozer/kodi-steamlink-launcher</source>
     <news>
+      1.0.0 Use Python 3 for Kodi 19.4 (Matrix)
       0.0.2 Stop kodi to save resources and use heartbeat to detect kodi restart
       0.0.1 Initial release
     </news>


### PR DESCRIPTION
Change addon python version and fix one difference for python3.

This allows the addon to work with Kodi Matrix (19.4)

Fixes #9 